### PR TITLE
fix: typed projection fixes for Amplifier event schemas

### DIFF
--- a/server/src/http/mod.rs
+++ b/server/src/http/mod.rs
@@ -506,8 +506,8 @@ fn handle_request(
                     _ => BytesRender::Base64,
                 };
                 let u64_format = match params.get("u64_format").map(|v| v.as_str()) {
-                    Some("number") => U64Format::Number,
-                    _ => U64Format::String,
+                    Some("string") => U64Format::String,
+                    _ => U64Format::Number,
                 };
                 let enum_render = match params.get("enum_render").map(|v| v.as_str()) {
                     Some("number") => EnumRender::Number,

--- a/server/src/projection/mod.rs
+++ b/server/src/projection/mod.rs
@@ -144,7 +144,8 @@ fn render_field_value(
     }
 
     // Handle type references - recursively project using the referenced type
-    if field.field_type == "ref" {
+    // Also recurse for "map" fields with a type_ref (e.g., metrics: map with ref to TurnMetrics)
+    if field.type_ref.is_some() && (field.field_type == "ref" || field.field_type == "map") {
         if let Some(type_ref) = &field.type_ref {
             return render_type_ref(value, type_ref, registry, options);
         }
@@ -152,7 +153,7 @@ fn render_field_value(
 
     let field_type = field.field_type.as_str();
     match field_type {
-        "u64" | "uint64" | "int64" => render_u64(value, options),
+        "u64" | "uint64" | "i64" | "int64" => render_u64(value, options),
         "u32" | "uint32" | "u8" | "uint8" | "int32" => render_int(value),
         "string" => render_string(value),
         "bool" => render_bool(value),

--- a/server/src/registry/mod.rs
+++ b/server/src/registry/mod.rs
@@ -348,6 +348,9 @@ fn normalize_version(version: u32, def: &TypeVersion) -> Result<TypeVersionSpec>
                     } else {
                         Some(ItemsSpec::Simple(t.clone()))
                     }
+                // Support shorthand: { "ref": "cxdb.SomeType" } without "type" key
+                } else if let Some(serde_json::Value::String(r)) = obj.get("ref") {
+                    Some(ItemsSpec::Ref(r.clone()))
                 } else {
                     None
                 }


### PR DESCRIPTION
## Summary

Four fixes to the projection/registry pipeline discovered during Amplifier CXDB integration work. These enable correct typed view rendering for complex event schemas with nested types, integer fields, and shorthand refs.

## Changes

### 1. `server/src/projection/mod.rs` - Add `"i64"` to integer type routing
The conversation-bundle uses `"i64"` for token counts and durations. Without this, `i64` fields fall through to the default string renderer instead of honoring `u64_format`.

### 2. `server/src/projection/mod.rs` - Recurse into `"map"` fields with `type_ref`
Fields declared as `"type": "map", "ref": "cxdb.TurnMetrics"` were not recursively projected. Only `"type": "ref"` fields were recursed into. This fix widens the guard to also recurse when a `type_ref` is present on `"map"` fields.

### 3. `server/src/http/mod.rs` - Default `u64_format` to Number
Token counts and durations are < 2^53, making JSON integers safe. The default is flipped from String to Number. Explicit `?u64_format=string` still works as an override.

### 4. `server/src/registry/mod.rs` - Support shorthand ref in array items
The shorthand `"items": {"ref": "cxdb.ToolCallItem"}` (without a `"type": "ref"` wrapper) was not parsed. This adds an `else if` branch to handle the shorthand format.

## Testing

These fixes were identified and documented during the Amplifier CXDB integration project. Integration tests validate that:
- Token counts render as integers, not strings
- Nested types (metrics, tool call results) render with named fields
- Array items with shorthand refs are recursively projected

## Related

- [amplifier-module-hooks-cxdb-events](https://github.com/colombod/amplifier-module-hooks-cxdb-events) - The hook module that writes Amplifier events to CXDB
- [cxdb-amplifier-research](https://github.com/colombod/cxdb-amplifier-research) - Design docs and research

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)