### PR TITLE
fix: proxy /healthz to correct backend path

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -65,7 +65,7 @@ http {
 
         # Health check endpoint
         location /healthz {
-            proxy_pass http://127.0.0.1:9010/health;
+            proxy_pass http://127.0.0.1:9010/healthz;
             access_log off;
         }
     }


### PR DESCRIPTION
## Summary
- Fix nginx health check proxy to forward `/healthz` → `/healthz` (was `/health`)
- Closes #3

## Root Cause
The CXDB server serves its health endpoint at `/healthz`, but the nginx config proxied to `/health`. The UI polls `/healthz` through nginx, gets a 404, and shows "Server offline" — never fetching contexts.

## Test plan
- [ ] Build Docker image with fix
- [ ] Navigate to UI — should show "Server online" and list contexts
- [ ] Verify `curl http://localhost:9020/healthz` returns `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)